### PR TITLE
AND-8319 Make single contract for EthereumTransactionBuilder

### DIFF
--- a/blockchain/src/main/java/com/tangem/blockchain/blockchains/decimal/DecimalWalletManager.kt
+++ b/blockchain/src/main/java/com/tangem/blockchain/blockchains/decimal/DecimalWalletManager.kt
@@ -1,9 +1,9 @@
 package com.tangem.blockchain.blockchains.decimal
 
-import com.tangem.blockchain.blockchains.ethereum.CompiledEthereumTransaction
-import com.tangem.blockchain.blockchains.ethereum.EthereumTransactionBuilder
 import com.tangem.blockchain.blockchains.ethereum.EthereumWalletManager
 import com.tangem.blockchain.blockchains.ethereum.network.EthereumNetworkProvider
+import com.tangem.blockchain.blockchains.ethereum.txbuilder.EthereumCompiledTxInfo
+import com.tangem.blockchain.blockchains.ethereum.txbuilder.EthereumTransactionBuilder
 import com.tangem.blockchain.common.Amount
 import com.tangem.blockchain.common.TransactionData
 import com.tangem.blockchain.common.TransactionSigner
@@ -50,7 +50,7 @@ internal class DecimalWalletManager(
     override suspend fun sign(
         transactionData: TransactionData,
         signer: TransactionSigner,
-    ): Result<Pair<ByteArray, CompiledEthereumTransaction>> {
+    ): Result<Pair<ByteArray, EthereumCompiledTxInfo>> {
         transactionData.requireUncompiled()
         return super.sign(convertTransactionDataAddress(transactionData), signer)
     }

--- a/blockchain/src/main/java/com/tangem/blockchain/blockchains/ethereum/Chain.kt
+++ b/blockchain/src/main/java/com/tangem/blockchain/blockchains/ethereum/Chain.kt
@@ -3,28 +3,6 @@
 package com.tangem.blockchain.blockchains.ethereum
 
 import com.tangem.blockchain.common.Blockchain
-import com.tangem.blockchain.common.TransactionData
-import com.tangem.common.extensions.toDecompressedPublicKey
-import java.math.BigInteger
-
-class EthereumTransactionBuilder(
-    walletPublicKey: ByteArray,
-    private val blockchain: Blockchain,
-) {
-    private val walletPublicKey: ByteArray = walletPublicKey.toDecompressedPublicKey().sliceArray(1..64)
-
-    fun buildToSign(transactionData: TransactionData, nonce: BigInteger?): CompiledEthereumTransaction {
-        return EthereumUtils.buildTransactionToSign(
-            transactionData = transactionData,
-            nonce = nonce,
-            blockchain = blockchain,
-        )
-    }
-
-    fun buildToSend(signature: ByteArray, transactionToSign: CompiledEthereumTransaction): ByteArray {
-        return EthereumUtils.prepareTransactionToSend(signature, transactionToSign, walletPublicKey, blockchain)
-    }
-}
 
 enum class Chain(val id: Int, val blockchain: Blockchain?) {
     Mainnet(id = 1, blockchain = Blockchain.Ethereum),

--- a/blockchain/src/main/java/com/tangem/blockchain/blockchains/ethereum/EthereumGasLoader.kt
+++ b/blockchain/src/main/java/com/tangem/blockchain/blockchains/ethereum/EthereumGasLoader.kt
@@ -2,7 +2,6 @@ package com.tangem.blockchain.blockchains.ethereum
 
 import com.tangem.blockchain.common.Amount
 import com.tangem.blockchain.extensions.Result
-import org.kethereum.model.Transaction
 import java.math.BigInteger
 
 interface EthereumGasLoader {
@@ -10,13 +9,3 @@ interface EthereumGasLoader {
     suspend fun getGasLimit(amount: Amount, destination: String): Result<BigInteger>
     suspend fun getGasLimit(amount: Amount, destination: String, data: String): Result<BigInteger>
 }
-
-data class CompiledEthereumTransaction(
-    val transaction: Transaction,
-    val hash: ByteArray,
-)
-
-data class SignedEthereumTransaction(
-    val compiledTransaction: CompiledEthereumTransaction,
-    val signature: ByteArray,
-)

--- a/blockchain/src/main/java/com/tangem/blockchain/blockchains/ethereum/EthereumTransactionExtras.kt
+++ b/blockchain/src/main/java/com/tangem/blockchain/blockchains/ethereum/EthereumTransactionExtras.kt
@@ -3,8 +3,8 @@ package com.tangem.blockchain.blockchains.ethereum
 import com.tangem.blockchain.common.TransactionExtras
 import java.math.BigInteger
 
-class EthereumTransactionExtras(
-    val data: ByteArray,
+data class EthereumTransactionExtras(
+    val data: ByteArray? = null,
     val gasLimit: BigInteger? = null,
     val nonce: BigInteger? = null,
 ) : TransactionExtras

--- a/blockchain/src/main/java/com/tangem/blockchain/blockchains/ethereum/eip1559/EthereumLikeBlockchainExt.kt
+++ b/blockchain/src/main/java/com/tangem/blockchain/blockchains/ethereum/eip1559/EthereumLikeBlockchainExt.kt
@@ -1,0 +1,49 @@
+package com.tangem.blockchain.blockchains.ethereum.eip1559
+
+import com.tangem.blockchain.common.Blockchain
+
+/** Returns true if the blockchain supports EIP1559 */
+internal val Blockchain.isSupportEIP1559: Boolean
+    get() {
+        if (!isEvm()) return false
+
+        return when (this) {
+            Blockchain.Ethereum,
+            Blockchain.BSC,
+            Blockchain.Polygon,
+            Blockchain.Avalanche,
+            Blockchain.Fantom,
+            Blockchain.Arbitrum,
+            Blockchain.Gnosis,
+            Blockchain.Optimism,
+            Blockchain.Cronos,
+            Blockchain.Decimal,
+            Blockchain.Areon,
+            Blockchain.Playa3ull,
+            Blockchain.PulseChain,
+            Blockchain.Manta,
+            Blockchain.Mantle,
+            Blockchain.Flare,
+            Blockchain.Base,
+            -> true
+            Blockchain.EthereumClassic, // eth_feeHistory all zeroes
+            Blockchain.EthereumPow, // eth_feeHistory with zeros
+            Blockchain.Dischain, // eth_feeHistory with zeros
+            Blockchain.Kava, // eth_feeHistory zero or null
+            Blockchain.OctaSpace, // eth_feeHistory all zeroes
+            Blockchain.Shibarium, // wrong base fee in eth_feeHistory. wei instead of gwei
+            Blockchain.RSK,
+            Blockchain.Telos,
+            Blockchain.XDC,
+            Blockchain.Aurora,
+            Blockchain.ZkSyncEra,
+            Blockchain.Moonbeam,
+            Blockchain.PolygonZkEVM,
+            Blockchain.Moonriver,
+            Blockchain.Taraxa,
+            Blockchain.Cyber,
+            Blockchain.Blast,
+            -> false
+            else -> error("Don't forget about evm here")
+        }
+    }

--- a/blockchain/src/main/java/com/tangem/blockchain/blockchains/ethereum/txbuilder/EthereumCompiledTxInfo.kt
+++ b/blockchain/src/main/java/com/tangem/blockchain/blockchains/ethereum/txbuilder/EthereumCompiledTxInfo.kt
@@ -1,0 +1,28 @@
+package com.tangem.blockchain.blockchains.ethereum.txbuilder
+
+import org.kethereum.model.Transaction
+
+/** Ethereum compiled transaction */
+sealed interface EthereumCompiledTxInfo {
+
+    /** Hash of transaction */
+    val hash: ByteArray
+
+    /**
+     * Compiled transaction info for legacy way of building transaction
+     *
+     * @property hash        hash
+     * @property transaction transaction
+     */
+    data class Legacy(
+        override val hash: ByteArray,
+        val transaction: Transaction,
+    ) : EthereumCompiledTxInfo
+
+    /**
+     * Compiled transaction info for building transaction by TW
+     *
+     * @property hash hash
+     */
+    data class TWInfo(override val hash: ByteArray) : EthereumCompiledTxInfo
+}

--- a/blockchain/src/main/java/com/tangem/blockchain/blockchains/ethereum/txbuilder/EthereumLegacyTransactionBuilder.kt
+++ b/blockchain/src/main/java/com/tangem/blockchain/blockchains/ethereum/txbuilder/EthereumLegacyTransactionBuilder.kt
@@ -1,0 +1,30 @@
+package com.tangem.blockchain.blockchains.ethereum.txbuilder
+
+import com.tangem.blockchain.blockchains.ethereum.EthereumUtils
+import com.tangem.blockchain.common.TransactionData
+import com.tangem.blockchain.common.Wallet
+
+/**
+ * Ethereum legacy transaction builder
+ *
+ * @param wallet wallet
+ */
+internal class EthereumLegacyTransactionBuilder(wallet: Wallet) : EthereumTransactionBuilder(wallet = wallet) {
+
+    override fun buildForSign(transaction: TransactionData): EthereumCompiledTxInfo {
+        return EthereumUtils.buildTransactionToSign(transactionData = transaction, blockchain = blockchain)
+    }
+
+    override fun buildForSend(
+        transaction: TransactionData,
+        signature: ByteArray,
+        compiledTransaction: EthereumCompiledTxInfo,
+    ): ByteArray {
+        return EthereumUtils.prepareTransactionToSend(
+            signature = signature,
+            transactionToSign = compiledTransaction as EthereumCompiledTxInfo.Legacy,
+            walletPublicKey = publicKey,
+            blockchain = blockchain,
+        )
+    }
+}

--- a/blockchain/src/main/java/com/tangem/blockchain/blockchains/ethereum/txbuilder/EthereumTransactionBuilder.kt
+++ b/blockchain/src/main/java/com/tangem/blockchain/blockchains/ethereum/txbuilder/EthereumTransactionBuilder.kt
@@ -1,0 +1,57 @@
+package com.tangem.blockchain.blockchains.ethereum.txbuilder
+
+import com.tangem.blockchain.blockchains.ethereum.eip1559.isSupportEIP1559
+import com.tangem.blockchain.common.TransactionData
+import com.tangem.blockchain.common.Wallet
+import com.tangem.blockchain.common.di.DepsContainer
+import com.tangem.common.extensions.toDecompressedPublicKey
+
+/**
+ * Ethereum transaction builder
+ *
+ * @param wallet wallet
+ */
+abstract class EthereumTransactionBuilder(wallet: Wallet) {
+
+    /** Decompressed wallet public key */
+    protected val publicKey by lazy {
+        wallet.publicKey.blockchainKey.toDecompressedPublicKey().sliceArray(1..64)
+    }
+
+    /** Blockchain */
+    protected val blockchain by lazy(wallet::blockchain)
+
+    /**
+     * Build for signing transaction
+     *
+     * @param transaction transaction data
+     */
+    abstract fun buildForSign(transaction: TransactionData): EthereumCompiledTxInfo
+
+    /**
+     * Build for sending transaction
+     *
+     * @param transaction         transaction data
+     * @param signature           signature
+     * @param compiledTransaction compiled transaction info
+     */
+    abstract fun buildForSend(
+        transaction: TransactionData,
+        signature: ByteArray,
+        compiledTransaction: EthereumCompiledTxInfo,
+    ): ByteArray
+
+    companion object {
+
+        /** Create [EthereumTransactionBuilder] using [Wallet] */
+        fun create(wallet: Wallet): EthereumTransactionBuilder {
+            val isEthereumEIP1559Enabled = DepsContainer.blockchainFeatureToggles.isEthereumEIP1559Enabled
+
+            return if (isEthereumEIP1559Enabled && wallet.blockchain.isSupportEIP1559) {
+                EthereumTWTransactionBuilder(wallet)
+            } else {
+                EthereumLegacyTransactionBuilder(wallet)
+            }
+        }
+    }
+}

--- a/blockchain/src/main/java/com/tangem/blockchain/blockchains/mantle/MantleWalletManager.kt
+++ b/blockchain/src/main/java/com/tangem/blockchain/blockchains/mantle/MantleWalletManager.kt
@@ -1,10 +1,10 @@
 package com.tangem.blockchain.blockchains.mantle
 
-import com.tangem.blockchain.blockchains.ethereum.CompiledEthereumTransaction
-import com.tangem.blockchain.blockchains.ethereum.EthereumTransactionBuilder
 import com.tangem.blockchain.blockchains.ethereum.EthereumTransactionExtras
 import com.tangem.blockchain.blockchains.ethereum.EthereumWalletManager
 import com.tangem.blockchain.blockchains.ethereum.network.EthereumNetworkProvider
+import com.tangem.blockchain.blockchains.ethereum.txbuilder.EthereumCompiledTxInfo
+import com.tangem.blockchain.blockchains.ethereum.txbuilder.EthereumTransactionBuilder
 import com.tangem.blockchain.common.*
 import com.tangem.blockchain.common.transaction.Fee
 import com.tangem.blockchain.common.transaction.TransactionFee
@@ -60,7 +60,7 @@ class MantleWalletManager(
     override suspend fun sign(
         transactionData: TransactionData,
         signer: TransactionSigner,
-    ): Result<Pair<ByteArray, CompiledEthereumTransaction>> {
+    ): Result<Pair<ByteArray, EthereumCompiledTxInfo>> {
         return when (transactionData) {
             is TransactionData.Uncompiled -> {
                 when (transactionData.amount.type) {
@@ -82,7 +82,7 @@ class MantleWalletManager(
     private suspend fun signCoinTransaction(
         transactionData: TransactionData.Uncompiled,
         signer: TransactionSigner,
-    ): Result<Pair<ByteArray, CompiledEthereumTransaction>> {
+    ): Result<Pair<ByteArray, EthereumCompiledTxInfo>> {
         val fee = requireEthereumFee(transactionData.fee)
 
         val patchedFee = fee.copy(

--- a/blockchain/src/main/java/com/tangem/blockchain/blockchains/optimism/EthereumOptimisticRollupWalletManager.kt
+++ b/blockchain/src/main/java/com/tangem/blockchain/blockchains/optimism/EthereumOptimisticRollupWalletManager.kt
@@ -1,11 +1,11 @@
 package com.tangem.blockchain.blockchains.optimism
 
-import com.tangem.blockchain.blockchains.ethereum.CompiledEthereumTransaction
-import com.tangem.blockchain.blockchains.ethereum.EthereumTransactionBuilder
 import com.tangem.blockchain.blockchains.ethereum.EthereumTransactionExtras
 import com.tangem.blockchain.blockchains.ethereum.EthereumWalletManager
 import com.tangem.blockchain.blockchains.ethereum.network.ContractCallData
 import com.tangem.blockchain.blockchains.ethereum.network.EthereumNetworkProvider
+import com.tangem.blockchain.blockchains.ethereum.txbuilder.EthereumCompiledTxInfo
+import com.tangem.blockchain.blockchains.ethereum.txbuilder.EthereumTransactionBuilder
 import com.tangem.blockchain.common.*
 import com.tangem.blockchain.common.transaction.Fee
 import com.tangem.blockchain.common.transaction.TransactionFee
@@ -140,7 +140,7 @@ class EthereumOptimisticRollupWalletManager(
     override suspend fun sign(
         transactionData: TransactionData,
         signer: TransactionSigner,
-    ): Result<Pair<ByteArray, CompiledEthereumTransaction>> {
+    ): Result<Pair<ByteArray, EthereumCompiledTxInfo>> {
         transactionData.requireUncompiled()
 
         // We need to subtract layer 1 fee, because it is deducted automatically

--- a/blockchain/src/main/java/com/tangem/blockchain/blockchains/telos/TelosWalletManager.kt
+++ b/blockchain/src/main/java/com/tangem/blockchain/blockchains/telos/TelosWalletManager.kt
@@ -1,8 +1,8 @@
 package com.tangem.blockchain.blockchains.telos
 
-import com.tangem.blockchain.blockchains.ethereum.EthereumTransactionBuilder
 import com.tangem.blockchain.blockchains.ethereum.EthereumWalletManager
 import com.tangem.blockchain.blockchains.ethereum.network.EthereumNetworkProvider
+import com.tangem.blockchain.blockchains.ethereum.txbuilder.EthereumTransactionBuilder
 import com.tangem.blockchain.common.Amount
 import com.tangem.blockchain.common.Wallet
 import com.tangem.blockchain.common.toBlockchainSdkError

--- a/blockchain/src/main/java/com/tangem/blockchain/blockchains/xdc/XDCWalletManager.kt
+++ b/blockchain/src/main/java/com/tangem/blockchain/blockchains/xdc/XDCWalletManager.kt
@@ -1,9 +1,9 @@
 package com.tangem.blockchain.blockchains.xdc
 
-import com.tangem.blockchain.blockchains.ethereum.CompiledEthereumTransaction
-import com.tangem.blockchain.blockchains.ethereum.EthereumTransactionBuilder
 import com.tangem.blockchain.blockchains.ethereum.EthereumWalletManager
 import com.tangem.blockchain.blockchains.ethereum.network.EthereumNetworkProvider
+import com.tangem.blockchain.blockchains.ethereum.txbuilder.EthereumCompiledTxInfo
+import com.tangem.blockchain.blockchains.ethereum.txbuilder.EthereumTransactionBuilder
 import com.tangem.blockchain.common.TransactionData
 import com.tangem.blockchain.common.TransactionSigner
 import com.tangem.blockchain.common.Wallet
@@ -27,7 +27,7 @@ internal class XDCWalletManager(
     override suspend fun sign(
         transactionData: TransactionData,
         signer: TransactionSigner,
-    ): Result<Pair<ByteArray, CompiledEthereumTransaction>> {
+    ): Result<Pair<ByteArray, EthereumCompiledTxInfo>> {
         transactionData.requireUncompiled()
         return super.sign(convertTransactionDataAddress(transactionData), signer)
     }

--- a/blockchain/src/main/java/com/tangem/blockchain/common/assembly/impl/DecimalWalletManagerAssembly.kt
+++ b/blockchain/src/main/java/com/tangem/blockchain/common/assembly/impl/DecimalWalletManagerAssembly.kt
@@ -3,7 +3,7 @@ package com.tangem.blockchain.common.assembly.impl
 import com.tangem.blockchain.blockchains.decimal.DecimalNetworkService
 import com.tangem.blockchain.blockchains.decimal.DecimalProvidersBuilder
 import com.tangem.blockchain.blockchains.decimal.DecimalWalletManager
-import com.tangem.blockchain.blockchains.ethereum.EthereumTransactionBuilder
+import com.tangem.blockchain.blockchains.ethereum.txbuilder.EthereumTransactionBuilder
 import com.tangem.blockchain.common.assembly.WalletManagerAssembly
 import com.tangem.blockchain.common.assembly.WalletManagerAssemblyInput
 
@@ -13,10 +13,7 @@ internal object DecimalWalletManagerAssembly : WalletManagerAssembly<DecimalWall
         return with(input.wallet) {
             DecimalWalletManager(
                 wallet = this,
-                transactionBuilder = EthereumTransactionBuilder(
-                    walletPublicKey = publicKey.blockchainKey,
-                    blockchain = blockchain,
-                ),
+                transactionBuilder = EthereumTransactionBuilder.create(wallet = input.wallet),
                 networkProvider = DecimalNetworkService(
                     jsonRpcProviders = DecimalProvidersBuilder(input.providerTypes).build(blockchain),
                 ),

--- a/blockchain/src/main/java/com/tangem/blockchain/common/assembly/impl/EthereumLikeWalletManagerAssembly.kt
+++ b/blockchain/src/main/java/com/tangem/blockchain/common/assembly/impl/EthereumLikeWalletManagerAssembly.kt
@@ -1,10 +1,10 @@
 package com.tangem.blockchain.common.assembly.impl
 
-import com.tangem.blockchain.blockchains.ethereum.EthereumTransactionBuilder
 import com.tangem.blockchain.blockchains.ethereum.EthereumWalletManager
 import com.tangem.blockchain.blockchains.ethereum.network.EthereumJsonRpcProvider
 import com.tangem.blockchain.blockchains.ethereum.network.EthereumNetworkService
 import com.tangem.blockchain.blockchains.ethereum.providers.*
+import com.tangem.blockchain.blockchains.ethereum.txbuilder.EthereumTransactionBuilder
 import com.tangem.blockchain.common.Blockchain
 import com.tangem.blockchain.common.BlockchainSdkConfig
 import com.tangem.blockchain.common.assembly.WalletManagerAssembly
@@ -19,10 +19,7 @@ internal object EthereumLikeWalletManagerAssembly : WalletManagerAssembly<Ethere
         with(input.wallet) {
             return EthereumWalletManager(
                 wallet = this,
-                transactionBuilder = EthereumTransactionBuilder(
-                    walletPublicKey = publicKey.blockchainKey,
-                    blockchain = blockchain,
-                ),
+                transactionBuilder = EthereumTransactionBuilder.create(wallet = input.wallet),
                 networkProvider = EthereumNetworkService(
                     jsonRpcProviders = getProvidersBuilder(blockchain, input.providerTypes, input.config)
                         .build(blockchain),

--- a/blockchain/src/main/java/com/tangem/blockchain/common/assembly/impl/EthereumOptimisticRollupWalletManagerAssembly.kt
+++ b/blockchain/src/main/java/com/tangem/blockchain/common/assembly/impl/EthereumOptimisticRollupWalletManagerAssembly.kt
@@ -1,12 +1,12 @@
 package com.tangem.blockchain.common.assembly.impl
 
-import com.tangem.blockchain.blockchains.ethereum.EthereumTransactionBuilder
 import com.tangem.blockchain.blockchains.ethereum.network.EthereumJsonRpcProvider
 import com.tangem.blockchain.blockchains.ethereum.network.EthereumNetworkService
 import com.tangem.blockchain.blockchains.ethereum.providers.BaseProvidersBuilder
 import com.tangem.blockchain.blockchains.ethereum.providers.BlastProvidersBuilder
 import com.tangem.blockchain.blockchains.ethereum.providers.CyberProvidersBuilder
 import com.tangem.blockchain.blockchains.ethereum.providers.MantaProvidersBuilder
+import com.tangem.blockchain.blockchains.ethereum.txbuilder.EthereumTransactionBuilder
 import com.tangem.blockchain.blockchains.optimism.EthereumOptimisticRollupWalletManager
 import com.tangem.blockchain.blockchains.optimism.OptimismProvidersBuilder
 import com.tangem.blockchain.common.Blockchain
@@ -23,10 +23,7 @@ internal object EthereumOptimisticRollupWalletManagerAssembly :
         with(input.wallet) {
             return EthereumOptimisticRollupWalletManager(
                 wallet = this,
-                transactionBuilder = EthereumTransactionBuilder(
-                    walletPublicKey = publicKey.blockchainKey,
-                    blockchain = blockchain,
-                ),
+                transactionBuilder = EthereumTransactionBuilder.create(wallet = input.wallet),
                 networkProvider = EthereumNetworkService(
                     jsonRpcProviders = getProvidersBuilder(blockchain, input.providerTypes, input.config)
                         .build(blockchain),

--- a/blockchain/src/main/java/com/tangem/blockchain/common/assembly/impl/EthereumWalletManagerAssembly.kt
+++ b/blockchain/src/main/java/com/tangem/blockchain/common/assembly/impl/EthereumWalletManagerAssembly.kt
@@ -1,9 +1,9 @@
 package com.tangem.blockchain.common.assembly.impl
 
 import com.tangem.blockchain.blockchains.ethereum.EthereumProvidersBuilder
-import com.tangem.blockchain.blockchains.ethereum.EthereumTransactionBuilder
 import com.tangem.blockchain.blockchains.ethereum.EthereumWalletManager
 import com.tangem.blockchain.blockchains.ethereum.network.EthereumNetworkService
+import com.tangem.blockchain.blockchains.ethereum.txbuilder.EthereumTransactionBuilder
 import com.tangem.blockchain.common.assembly.WalletManagerAssembly
 import com.tangem.blockchain.common.assembly.WalletManagerAssemblyInput
 import com.tangem.blockchain.network.blockcypher.BlockcypherNetworkProvider
@@ -15,10 +15,7 @@ internal object EthereumWalletManagerAssembly : WalletManagerAssembly<EthereumWa
         with(input.wallet) {
             return EthereumWalletManager(
                 wallet = this,
-                transactionBuilder = EthereumTransactionBuilder(
-                    walletPublicKey = publicKey.blockchainKey,
-                    blockchain = blockchain,
-                ),
+                transactionBuilder = EthereumTransactionBuilder.create(wallet = input.wallet),
                 networkProvider = EthereumNetworkService(
                     jsonRpcProviders = EthereumProvidersBuilder(input.providerTypes, input.config).build(blockchain),
                     blockcypherNetworkProvider = BlockcypherNetworkProvider(

--- a/blockchain/src/main/java/com/tangem/blockchain/common/assembly/impl/MantleWalletManagerAssembly.kt
+++ b/blockchain/src/main/java/com/tangem/blockchain/common/assembly/impl/MantleWalletManagerAssembly.kt
@@ -1,8 +1,8 @@
 package com.tangem.blockchain.common.assembly.impl
 
-import com.tangem.blockchain.blockchains.ethereum.EthereumTransactionBuilder
 import com.tangem.blockchain.blockchains.ethereum.network.EthereumNetworkService
 import com.tangem.blockchain.blockchains.ethereum.providers.MantleProvidersBuilder
+import com.tangem.blockchain.blockchains.ethereum.txbuilder.EthereumTransactionBuilder
 import com.tangem.blockchain.blockchains.mantle.MantleWalletManager
 import com.tangem.blockchain.common.assembly.WalletManagerAssembly
 import com.tangem.blockchain.common.assembly.WalletManagerAssemblyInput
@@ -14,10 +14,7 @@ internal object MantleWalletManagerAssembly : WalletManagerAssembly<MantleWallet
         return with(input.wallet) {
             MantleWalletManager(
                 wallet = this,
-                transactionBuilder = EthereumTransactionBuilder(
-                    walletPublicKey = publicKey.blockchainKey,
-                    blockchain = blockchain,
-                ),
+                transactionBuilder = EthereumTransactionBuilder.create(wallet = input.wallet),
                 networkProvider = EthereumNetworkService(
                     jsonRpcProviders = MantleProvidersBuilder(input.providerTypes).build(blockchain),
                 ),

--- a/blockchain/src/main/java/com/tangem/blockchain/common/assembly/impl/TelosWalletManagerAssembly.kt
+++ b/blockchain/src/main/java/com/tangem/blockchain/common/assembly/impl/TelosWalletManagerAssembly.kt
@@ -1,7 +1,7 @@
 package com.tangem.blockchain.common.assembly.impl
 
-import com.tangem.blockchain.blockchains.ethereum.EthereumTransactionBuilder
 import com.tangem.blockchain.blockchains.ethereum.network.EthereumNetworkService
+import com.tangem.blockchain.blockchains.ethereum.txbuilder.EthereumTransactionBuilder
 import com.tangem.blockchain.blockchains.telos.TelosProvidersBuilder
 import com.tangem.blockchain.blockchains.telos.TelosWalletManager
 import com.tangem.blockchain.common.assembly.WalletManagerAssembly
@@ -13,10 +13,7 @@ internal object TelosWalletManagerAssembly : WalletManagerAssembly<TelosWalletMa
         with(input.wallet) {
             return TelosWalletManager(
                 wallet = this,
-                transactionBuilder = EthereumTransactionBuilder(
-                    walletPublicKey = publicKey.blockchainKey,
-                    blockchain = blockchain,
-                ),
+                transactionBuilder = EthereumTransactionBuilder.create(wallet = input.wallet),
                 networkProvider = EthereumNetworkService(
                     jsonRpcProviders = TelosProvidersBuilder(
                         input.providerTypes,

--- a/blockchain/src/main/java/com/tangem/blockchain/common/assembly/impl/XDCWalletManagerAssembly.kt
+++ b/blockchain/src/main/java/com/tangem/blockchain/common/assembly/impl/XDCWalletManagerAssembly.kt
@@ -1,7 +1,7 @@
 package com.tangem.blockchain.common.assembly.impl
 
-import com.tangem.blockchain.blockchains.ethereum.EthereumTransactionBuilder
 import com.tangem.blockchain.blockchains.ethereum.network.EthereumNetworkService
+import com.tangem.blockchain.blockchains.ethereum.txbuilder.EthereumTransactionBuilder
 import com.tangem.blockchain.blockchains.xdc.XDCProvidersBuilder
 import com.tangem.blockchain.blockchains.xdc.XDCWalletManager
 import com.tangem.blockchain.common.assembly.WalletManagerAssembly
@@ -13,10 +13,7 @@ internal object XDCWalletManagerAssembly : WalletManagerAssembly<XDCWalletManage
         return with(input.wallet) {
             XDCWalletManager(
                 wallet = this,
-                transactionBuilder = EthereumTransactionBuilder(
-                    walletPublicKey = publicKey.blockchainKey,
-                    blockchain = blockchain,
-                ),
+                transactionBuilder = EthereumTransactionBuilder.create(wallet = input.wallet),
                 networkProvider = EthereumNetworkService(
                     jsonRpcProviders = XDCProvidersBuilder(input.providerTypes, input.config).build(blockchain),
                 ),


### PR DESCRIPTION
- [x] Влить после отведения релиза

Файлов получилось много из-за того, что поменял расположение transactions builders и изменил сигнатуру метода sign (изменил возвращаемый тип). СМОТРИТЕ ПО КОММИТАМ!

- 1 коммит (основные изменения): создал абстрактный класс для старой и новой реализации `EthereumTransactionBuilder`; изменил сигнатуру метода `EthereumCompiledTxInfo` для поддержки работы с новым контрактом `EthereumTransactionBuilder`.

- 2 коммит: импорты, переименовывание и тд

- 3 коммит: изменение тестов (данные не менялись, только названия компонентов)